### PR TITLE
Update to support the latest versions of appengine and shelf_appengine

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,9 +6,9 @@ homepage: https://dart-endpoints.appspot.com/
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:
-  appengine: '>=0.2.0 <0.3.0'
+  appengine: '>=0.3.0 <0.4.0'
   googleapis: '>=0.3.0 <0.5.0'
   http: '>=0.11.1 <0.12.0'
-  shelf_appengine: '>=0.1.0 <0.2.0'
+  shelf_appengine: '>=0.2.0 <0.3.0'
 dev_dependencies:
   unittest: '>=0.11.0 <0.12.0'

--- a/tool/run_tests.sh
+++ b/tool/run_tests.sh
@@ -3,7 +3,7 @@
 REPO_ROOT=$( cd $(dirname $(dirname "${BASH_SOURCE[0]}" )) && pwd )
 
 # Source utility functions
-source "$REPO_ROOT/tools/utils.sh"
+source "$REPO_ROOT/tool/utils.sh"
 
 export RETURN_VALUE=0
 


### PR DESCRIPTION
Currently dart_endpoints is not usable with the current version of appengine and shelf_appengine. It seems the newer versions of both do not break dart_endpoints as all of the tests pass just fine when pubspec is updated.

Also there was a typo in your test script.
